### PR TITLE
Added ability for developer to override the value of the field programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ There is also a native iOS library called [TextFieldEffects](https://github.com/
 
 ![](screenshots/full.gif)
 
-## Installation 
+## Installation
 `$ npm install react-native-textinput-effects --save`
 
 You also need to install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) if you'd like to use a TextInputEffect component with an icon. Please check out [Installation section](https://github.com/oblador/react-native-vector-icons#installation) on that project.
@@ -21,6 +21,7 @@ You also need to install [react-native-vector-icons](https://github.com/oblador/
 |**`style`**|View Style Object|Applied to the root container of the input.|
 |**`labelStyle`**|View Style Object|Applied to the container of the label view.|
 |**`inputStyle`**|Text Style Object|Applied to the TextInput component.|
+|**`value`**|String|Override the value of the field. Usually only used with `onChangeText` and manual state handling.|
 
 You can also use [TextInput Props](https://facebook.github.io/react-native/docs/textinput.html#props). They'll be passed into TextInput component.
 

--- a/lib/BaseInput.js
+++ b/lib/BaseInput.js
@@ -44,7 +44,7 @@ export default class BaseInput extends Component {
   }
 
   componentWillReceiveProps (newProps) {
-    if (newProps.value !== this.state.value) this.setState({value: newProps.value})
+    if (newProps.value && newProps.value !== this.state.value) this.setState({value: newProps.value})
   }
 
   _onLayout(event) {

--- a/lib/BaseInput.js
+++ b/lib/BaseInput.js
@@ -43,6 +43,10 @@ export default class BaseInput extends Component {
     };
   }
 
+  componentWillReceiveProps (newProps) {
+    if (newProps.value !== this.state.value) this.setState({value: newProps.value})
+  }
+
   _onLayout(event) {
     this.setState({
       width: event.nativeEvent.layout.width,


### PR DESCRIPTION
In my use case I have a typeahead-style field where the user will type the beginning of another user's name and then be presented with a dropdown of options to choose from. When the user selects an option I set the value in the background but I also need the ability to change the text field to reflect the complete name of the user that was selected versus just the first few letters.

This pull request allows the developer to set a new value by simply passing the value property in to the component but does not interfere with the existing state tracking if a new value is not passed in.