### PR TITLE
changed order of style objects, so customStyles take precedence over defaults

### DIFF
--- a/lib/Fumi.js
+++ b/lib/Fumi.js
@@ -60,7 +60,7 @@ export default class Fumi extends BaseInput {
     const NEGATIVE_ANIM_PATH = ANIM_PATH * -1;
 
     return (
-      <View style={[containerStyle, styles.container]} onLayout={this._onLayout}>
+      <View style={[styles.container, containerStyle]} onLayout={this._onLayout}>
         <TouchableWithoutFeedback onPress={this._focus}>
           <AnimatedIcon
             name={iconName}


### PR DESCRIPTION
just changed the order. that way if someone wants to use Fumi but wants a different backgroundColor, for example, they can edit the style property and it will take precedence over styles.container's backgroundColor.