### PR TITLE
Fix separator style on Fumi

### DIFF
--- a/lib/Fumi.js
+++ b/lib/Fumi.js
@@ -150,6 +150,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: 1,
     backgroundColor: '#f0f0f0',
-    marginTop: -8,
+    top: 8,
   },
 });


### PR DESCRIPTION
Fixed issues where the separator was positioned at the top of the input instead of centered