### PR TITLE
fix icon output range

### DIFF
--- a/lib/Kohana.js
+++ b/lib/Kohana.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { PropTypes } from 'react';
 import {
   Animated,
   Easing,
@@ -33,13 +32,20 @@ export default class Kohana extends BaseInput {
     /*
      * Passed to react-native-vector-icons library as size prop.
      */
-    iconSize: PropTypes.number,
+	iconSize: PropTypes.number,
+	
+	/**
+	 * Used to pull icon a little bit, some icons are wider, a line may still be visible
+	 * @see https://github.com/halilb/react-native-textinput-effects/issues/51
+	 */
+	extraRange: PropTypes.number,
   };
 
   static defaultProps = {
     easing: Easing.bezier(0.2, 1, 0.3, 1),
     iconSize: 25,
-    useNativeDriver: false,
+	useNativeDriver: false,
+	extraRange: 0,
   };
 
   render() {
@@ -51,7 +57,8 @@ export default class Kohana extends BaseInput {
       label,
       style: containerStyle,
       inputStyle,
-      labelStyle,
+	  labelStyle,
+	  extraRange,
     } = this.props;
     const { focusedAnim, value } = this.state;
 
@@ -69,7 +76,7 @@ export default class Kohana extends BaseInput {
                 {
                   translateX: focusedAnim.interpolate({
                     inputRange: [0, 1],
-                    outputRange: [-15 - iconSize, 0],
+                    outputRange: [-15 - iconSize - extraRange, 0],
                   }),
                 },
               ],


### PR DESCRIPTION
Some icons are wider and some part of them still can be visible
https://github.com/halilb/react-native-textinput-effects/issues/51

What i did was include a prop to increment this range, so the issue can be easily fixed