### PR TITLE
Add icon and label container styles to Kohana

### DIFF
--- a/lib/Kohana.js
+++ b/lib/Kohana.js
@@ -52,6 +52,8 @@ export default class Kohana extends BaseInput {
       style: containerStyle,
       inputStyle,
       labelStyle,
+      iconContainerStyle,
+      labelContainerStyle,
     } = this.props;
     const { focusedAnim, value } = this.state;
 
@@ -73,6 +75,7 @@ export default class Kohana extends BaseInput {
                   }),
                 },
               ],
+              ...iconContainerStyle,
             }}
           >
             <Icon name={iconName} color={iconColor} size={iconSize} />
@@ -96,6 +99,7 @@ export default class Kohana extends BaseInput {
                 inputRange: [0, 1],
                 outputRange: [1, 0],
               }),
+              ...labelContainerStyle,
             }}
           >
             <Text style={[styles.label, labelStyle]}>


### PR DESCRIPTION
This allows me to configure the hard-coded `PADDING`, so I can have a Kohana component be whatever size I want. I've only tested this on Android, but it shouldn't affect iOS differently, since I'm just exposing some optional styles.