### PR TITLE
Update to use createRef instead of string refs

### DIFF
--- a/lib/Akira.js
+++ b/lib/Akira.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 import {
   Animated,
   Text,
   TextInput,
   TouchableWithoutFeedback,
   View,
-  StyleSheet,
-} from 'react-native';
+  StyleSheet
+} from "react-native";
 
-import BaseInput from './BaseInput';
+import BaseInput from "./BaseInput";
 
 const LABEL_HEIGHT = 24;
 const PADDING = 16;
@@ -20,13 +20,13 @@ export default class Akira extends BaseInput {
      * this is applied as active border and label color
      */
     borderColor: PropTypes.string,
-    height: PropTypes.number,
+    height: PropTypes.number
   };
 
   static defaultProps = {
-    borderColor: '#7A7593',
+    borderColor: "#7A7593",
     height: 48,
-    animationDuration: 200,
+    animationDuration: 200
   };
 
   render() {
@@ -36,13 +36,9 @@ export default class Akira extends BaseInput {
       height: inputHeight,
       inputStyle,
       labelStyle,
-      borderColor,
+      borderColor
     } = this.props;
-    const {
-      width,
-      focusedAnim,
-      value,
-    } = this.state;
+    const { width, focusedAnim, value } = this.state;
 
     return (
       <View style={containerStyle} onLayout={this._onLayout}>
@@ -55,86 +51,84 @@ export default class Akira extends BaseInput {
                 {
                   translateY: focusedAnim.interpolate({
                     inputRange: [0, 1],
-                    outputRange: [LABEL_HEIGHT + PADDING, 0],
-                  }),
-                },
-              ],
+                    outputRange: [LABEL_HEIGHT + PADDING, 0]
+                  })
+                }
+              ]
             }}
           >
-            <Text style={[styles.label, labelStyle]}>
-              {label}
-            </Text>
+            <Text style={[styles.label, labelStyle]}>{label}</Text>
           </Animated.View>
         </TouchableWithoutFeedback>
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,
             inputStyle,
             {
               width,
-              height: inputHeight,
-            },
+              height: inputHeight
+            }
           ]}
           value={value}
           onBlur={this._onBlur}
           onChange={this._onChange}
           onFocus={this._onFocus}
-          underlineColorAndroid={'transparent'}
+          underlineColorAndroid={"transparent"}
         />
         {/* left border */}
         <Animated.View
           style={{
-            position: 'absolute',
+            position: "absolute",
             left: 0,
             bottom: 0,
             height: inputHeight,
             width: focusedAnim.interpolate({
               inputRange: [0, 1],
-              outputRange: [6, 1],
+              outputRange: [6, 1]
             }),
-            backgroundColor: borderColor,
+            backgroundColor: borderColor
           }}
         />
         {/* top border */}
         <Animated.View
           style={{
-            position: 'absolute',
+            position: "absolute",
             top: LABEL_HEIGHT,
             width,
             height: focusedAnim.interpolate({
               inputRange: [0, 1],
-              outputRange: [6, 1],
+              outputRange: [6, 1]
             }),
-            backgroundColor: borderColor,
+            backgroundColor: borderColor
           }}
         />
         {/* right border */}
         <Animated.View
           style={{
-            position: 'absolute',
+            position: "absolute",
             right: 0,
             bottom: 0,
             height: inputHeight,
             width: focusedAnim.interpolate({
               inputRange: [0, 1],
-              outputRange: [6, 1],
+              outputRange: [6, 1]
             }),
-            backgroundColor: borderColor,
+            backgroundColor: borderColor
           }}
         />
         {/* bottom border */}
         <Animated.View
           style={{
-            position: 'absolute',
+            position: "absolute",
             bottom: 0,
             height: focusedAnim.interpolate({
               inputRange: [0, 1],
-              outputRange: [6, 1],
+              outputRange: [6, 1]
             }),
             width,
-            backgroundColor: borderColor,
+            backgroundColor: borderColor
           }}
         />
       </View>
@@ -144,18 +138,18 @@ export default class Akira extends BaseInput {
 
 const styles = StyleSheet.create({
   label: {
-    backgroundColor: 'transparent',
-    fontFamily: 'Arial',
+    backgroundColor: "transparent",
+    fontFamily: "Arial",
     fontSize: 14,
-    fontWeight: 'bold',
-    color: '#cc6055',
-    textAlign: 'center',
+    fontWeight: "bold",
+    color: "#cc6055",
+    textAlign: "center"
   },
   textInput: {
     paddingHorizontal: PADDING,
     padding: 0,
-    color: 'black',
+    color: "black",
     fontSize: 18,
-    textAlign: 'center',
-  },
+    textAlign: "center"
+  }
 });

--- a/lib/BaseInput.js
+++ b/lib/BaseInput.js
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 
 import { Animated, Text, View, ViewPropTypes } from 'react-native';
@@ -28,6 +28,7 @@ export default class BaseInput extends Component {
   constructor(props, context) {
     super(props, context);
 
+    this.input = createRef();
     this._onLayout = this._onLayout.bind(this);
     this._onChange = this._onChange.bind(this);
     this._onBlur = this._onBlur.bind(this);
@@ -51,7 +52,7 @@ export default class BaseInput extends Component {
 
       // animate input if it's active state has changed with the new value
       // and input is not focused currently.
-      const isFocused = this.refs.input.isFocused();
+      const isFocused = this.inputRef().isFocused();
       if (!isFocused) {
         const isActive = Boolean(newValue);
         if (isActive !== this.isActive) {
@@ -112,7 +113,7 @@ export default class BaseInput extends Component {
   // public methods
 
   inputRef() {
-    return this.refs.input;
+    return this.input.current;
   }
 
   focus() {

--- a/lib/Fumi.js
+++ b/lib/Fumi.js
@@ -143,7 +143,7 @@ export default class Fumi extends BaseInput {
           </Animated.View>
         </TouchableWithoutFeedback>
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,

--- a/lib/Hideo.js
+++ b/lib/Hideo.js
@@ -93,7 +93,7 @@ export default class Hideo extends BaseInput {
           </Animated.View>
         </TouchableWithoutFeedback>
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[styles.textInput, inputStyle]}
           value={value}

--- a/lib/Hoshi.js
+++ b/lib/Hoshi.js
@@ -57,7 +57,7 @@ export default class Hoshi extends BaseInput {
         onLayout={this._onLayout}
       >
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,

--- a/lib/Isao.js
+++ b/lib/Isao.js
@@ -70,7 +70,7 @@ export default class Isao extends BaseInput {
           ]}
         >
           <TextInput
-            ref="input"
+            ref={this.input}
             {...this.props}
             style={[
               styles.textInput,

--- a/lib/Jiro.js
+++ b/lib/Jiro.js
@@ -119,7 +119,7 @@ export default class Jiro extends BaseInput {
           ]}
         />
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,

--- a/lib/Kaede.js
+++ b/lib/Kaede.js
@@ -54,7 +54,7 @@ export default class Kaede extends BaseInput {
           }}
         >
           <TextInput
-            ref="input"
+            ref={this.input}
             {...this.props}
             style={[styles.textInput, inputStyle, { height: inputHeight }]}
             value={value}

--- a/lib/Kohana.js
+++ b/lib/Kohana.js
@@ -104,7 +104,7 @@ export default class Kohana extends BaseInput {
           </Animated.View>
         </TouchableWithoutFeedback>
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[styles.textInput, inputStyle]}
           value={value}

--- a/lib/Madoka.js
+++ b/lib/Madoka.js
@@ -52,7 +52,7 @@ export default class Madoka extends BaseInput {
           style={[styles.inputContainer, { borderBottomColor: borderColor }]}
         >
           <TextInput
-            ref="input"
+            ref={this.input}
             {...this.props}
             style={[
               styles.textInput,

--- a/lib/Makiko.js
+++ b/lib/Makiko.js
@@ -133,7 +133,7 @@ export default class Makiko extends BaseInput {
           }}
         />
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,

--- a/lib/Sae.js
+++ b/lib/Sae.js
@@ -92,7 +92,7 @@ export default class Sae extends BaseInput {
           </Animated.View>
         </TouchableWithoutFeedback>
         <TextInput
-          ref="input"
+          ref={this.input}
           {...this.props}
           style={[
             styles.textInput,


### PR DESCRIPTION
As of the latest React Native, string refs are considered legacy. They're likely to be removed in one of the future releases.

All instances of string refs have been replaced with the new createRef API. This also makes it Strict Mode-compliant. Otherwise, the latest version of React Native with Strict Mode on throws this warning: 

> WARNING: A string ref, "Input", has been found within a strict mode tree. String refs are a source of potential bugs and should be avoided. We recommend using createRef() instead.