### PR TITLE
Update BaseInput.js

### DIFF
--- a/lib/BaseInput.js
+++ b/lib/BaseInput.js
@@ -40,6 +40,7 @@ export default class BaseInput extends Component {
     this.state = {
       value,
       focusedAnim: new Animated.Value(value ? 1 : 0),
+      width: 0
     };
   }
 


### PR DESCRIPTION
After Upgrading to 58.4 the Hoshi-Input crashed.
This was related to an uninitialized **width** state variable at Hoshi.js:116
I traced it down to the BaseInput.js state initialization and added an default number value of 0

```
<Animated.View
          style={[
            styles.border,
            {
              width: focusedAnim.interpolate({
                inputRange: [0, 1],
116:          outputRange: [0, >>>>width<<<<],
              }),
              backgroundColor: borderColor,
              height: borderHeight,
            },
          ]}
        />
      </View>
``` 

Fixed RN ~58 crash: [39,"RCTView",1,{"position":"absolute","bottom":0,"left":0,"right":0,"width":"<<NaN>>","backgroundColor":436207616,"height":0.5}] is not usable as a native method argument

This error is located at:
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:153)
    in AnimatedComponent (at Hoshi.js:110)
    in RCTView (at View.js:45)
    in View (at Hoshi.js:50)
...