### PR TITLE
Fummi: Adjusting Icon's top position to iconSize

### DIFF
--- a/lib/Fumi.js
+++ b/lib/Fumi.js
@@ -84,11 +84,11 @@ export default class Fumi extends BaseInput {
               bottom: focusedAnim.interpolate({
                 inputRange: [0, 0.5, 0.51, 0.7, 1],
                 outputRange: [
-                  24,
+                  36-0.6*iconSize,
                   ANIM_PATH,
                   NEGATIVE_ANIM_PATH,
                   NEGATIVE_ANIM_PATH,
-                  24,
+                  36-0.6*iconSize,
                 ],
               }),
               color: focusedAnim.interpolate({


### PR DESCRIPTION
Icon wasn't keeping its position vertically centered when iconSize was different from 20.