### PR TITLE
Add missing Hoshi type - borderHeight

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -69,6 +69,7 @@ declare module "react-native-textinput-effects" {
   export interface HoshiProps extends CommonProps {
     maskColor?: string;
     borderColor?: string;
+    borderHeight?: number
   }
 
   class Hoshi extends BaseClass<HoshiProps> {}


### PR DESCRIPTION
Adding `borderHeight` missing type for Hoshi